### PR TITLE
Also accept the parameters in x-www-form-urlencoded format

### DIFF
--- a/src/main/java/ch/smartness/pbs/reporting/resources/KursParameterJson.java
+++ b/src/main/java/ch/smartness/pbs/reporting/resources/KursParameterJson.java
@@ -1,6 +1,7 @@
 package ch.smartness.pbs.reporting.resources;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.ws.rs.FormParam;
 
 public class KursParameterJson {
 
@@ -19,6 +20,7 @@ public class KursParameterJson {
 		return name;
 	}
 
+	@FormParam("name")
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -28,6 +30,7 @@ public class KursParameterJson {
 		return vorname;
 	}
 
+	@FormParam("vorname")
 	public void setVorname(String vorname) {
 		this.vorname = vorname;
 	}
@@ -37,6 +40,7 @@ public class KursParameterJson {
 		return wohnort;
 	}
 
+	@FormParam("wohnort")
 	public void setWohnort(String wohnort) {
 		this.wohnort = wohnort;
 	}
@@ -46,6 +50,7 @@ public class KursParameterJson {
 		return dauer;
 	}
 
+	@FormParam("dauer")
 	public void setDauer(String dauer) {
 		this.dauer = dauer;
 	}
@@ -55,6 +60,7 @@ public class KursParameterJson {
 		return kursOrt;
 	}
 
+	@FormParam("kursOrt")
 	public void setKursOrt(String kursOrt) {
 		this.kursOrt = kursOrt;
 	}
@@ -64,6 +70,7 @@ public class KursParameterJson {
 		return organisator;
 	}
 
+	@FormParam("organisator")
 	public void setOrganisator(String organisator) {
 		this.organisator = organisator;
 	}
@@ -73,6 +80,7 @@ public class KursParameterJson {
 		return geburtstag;
 	}
 
+	@FormParam("geburtstag")
 	public void setGeburtstag(String geburtstag) {
 		this.geburtstag = geburtstag;
 	}
@@ -82,6 +90,7 @@ public class KursParameterJson {
 		return this.anrede;
 	}
 
+	@FormParam("anrede")
 	public void setAnrede(String anrede) {
 		this.anrede = anrede;
 	}

--- a/src/main/java/ch/smartness/pbs/reporting/resources/KursRendererResource.java
+++ b/src/main/java/ch/smartness/pbs/reporting/resources/KursRendererResource.java
@@ -2,6 +2,7 @@ package ch.smartness.pbs.reporting.resources;
 
 import java.io.IOException;
 
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -52,27 +53,38 @@ public class KursRendererResource {
     public KursParameterJson getDemoParameter(){
     	return createDemoParameter();
     }
-    
+
     @GET
     @Path("/demo/pdf/{kurs}/{lang}")
     @Produces("application/pdf")
     @Timed
     public byte[] getPdfDemo(@PathParam("kurs") String kurs, @PathParam("lang") String lang) throws Exception {
-    	KursParameterJson parameter = createDemoParameter();
-		
-		
-		return renderPdf(kurs, lang, parameter);
+        KursParameterJson parameter = createDemoParameter();
+
+
+        return renderPdf(kurs, lang, parameter);
     }
-    
+
     @POST
     @Path("/pdf/{kurs}/{lang}")
     @Produces("application/pdf")
     @Consumes(MediaType.APPLICATION_JSON)
     @Timed
-    public byte[] getPdf(@PathParam("kurs") String kurs, @PathParam("lang") String lang, KursParameterJson kpj) throws Exception {
-    	System.out.println(kpj);
-    	
-		return renderPdf(kurs, lang, kpj);
+    public byte[] getPdfFromJson(@PathParam("kurs") String kurs, @PathParam("lang") String lang, KursParameterJson kpj) throws Exception {
+        System.out.println(kpj);
+
+        return renderPdf(kurs, lang, kpj);
+    }
+
+    @POST
+    @Path("/pdf/{kurs}/{lang}")
+    @Produces("application/pdf")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Timed
+    public byte[] getPdfFromUrlencoded(@PathParam("kurs") String kurs, @PathParam("lang") String lang, @BeanParam KursParameterJson kpj) throws Exception {
+        System.out.println(kpj);
+
+        return renderPdf(kurs, lang, kpj);
     }
     
     public byte[] renderPdf(String kurs, String lang, KursParameterJson kpj) throws Exception{


### PR DESCRIPTION
Adds another variant of the main endpoint that accepts the data parameters in x-www-form-urlencoded format, so it is possible to trigger the POST request using an HTML form. This is accomplished using the @BeanParam / @FormParam annotations with the existing DTO class.