### PR TITLE
Make browser download the pdf

### DIFF
--- a/src/main/java/ch/smartness/pbs/reporting/resources/KursParameterJson.java
+++ b/src/main/java/ch/smartness/pbs/reporting/resources/KursParameterJson.java
@@ -1,6 +1,7 @@
 package ch.smartness.pbs.reporting.resources;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.ws.rs.FormParam;
 
 public class KursParameterJson {
 
@@ -19,6 +20,7 @@ public class KursParameterJson {
 		return name;
 	}
 
+	@FormParam("name")
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -28,6 +30,7 @@ public class KursParameterJson {
 		return vorname;
 	}
 
+	@FormParam("vorname")
 	public void setVorname(String vorname) {
 		this.vorname = vorname;
 	}
@@ -37,6 +40,7 @@ public class KursParameterJson {
 		return wohnort;
 	}
 
+	@FormParam("wohnort")
 	public void setWohnort(String wohnort) {
 		this.wohnort = wohnort;
 	}
@@ -46,6 +50,7 @@ public class KursParameterJson {
 		return dauer;
 	}
 
+	@FormParam("dauer")
 	public void setDauer(String dauer) {
 		this.dauer = dauer;
 	}
@@ -55,6 +60,7 @@ public class KursParameterJson {
 		return kursOrt;
 	}
 
+	@FormParam("kursOrt")
 	public void setKursOrt(String kursOrt) {
 		this.kursOrt = kursOrt;
 	}
@@ -64,6 +70,7 @@ public class KursParameterJson {
 		return organisator;
 	}
 
+	@FormParam("organisator")
 	public void setOrganisator(String organisator) {
 		this.organisator = organisator;
 	}
@@ -73,6 +80,7 @@ public class KursParameterJson {
 		return geburtstag;
 	}
 
+	@FormParam("geburtstag")
 	public void setGeburtstag(String geburtstag) {
 		this.geburtstag = geburtstag;
 	}
@@ -82,6 +90,7 @@ public class KursParameterJson {
 		return this.anrede;
 	}
 
+	@FormParam("anrede")
 	public void setAnrede(String anrede) {
 		this.anrede = anrede;
 	}

--- a/src/main/java/ch/smartness/pbs/reporting/resources/KursRendererResource.java
+++ b/src/main/java/ch/smartness/pbs/reporting/resources/KursRendererResource.java
@@ -2,6 +2,7 @@ package ch.smartness.pbs.reporting.resources;
 
 import java.io.IOException;
 
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -52,27 +53,38 @@ public class KursRendererResource {
     public KursParameterJson getDemoParameter(){
     	return createDemoParameter();
     }
-    
+
     @GET
     @Path("/demo/pdf/{kurs}/{lang}")
     @Produces("application/pdf")
     @Timed
     public byte[] getPdfDemo(@PathParam("kurs") String kurs, @PathParam("lang") String lang) throws Exception {
-    	KursParameterJson parameter = createDemoParameter();
-		
-		
-		return renderPdf(kurs, lang, parameter);
+        KursParameterJson parameter = createDemoParameter();
+
+
+        return renderPdf(kurs, lang, parameter);
     }
-    
+
     @POST
     @Path("/pdf/{kurs}/{lang}")
     @Produces("application/pdf")
     @Consumes(MediaType.APPLICATION_JSON)
     @Timed
-    public byte[] getPdf(@PathParam("kurs") String kurs, @PathParam("lang") String lang, KursParameterJson kpj) throws Exception {
-    	System.out.println(kpj);
-    	
-		return renderPdf(kurs, lang, kpj);
+    public byte[] getPdfFromJson(@PathParam("kurs") String kurs, @PathParam("lang") String lang, KursParameterJson kpj) throws Exception {
+        System.out.println(kpj);
+
+        return renderPdf(kurs, lang, kpj);
+    }
+
+    @POST
+    @Path("/pdf/{kurs}/{lang}")
+    @Produces("application/pdf")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Timed
+    public byte[] getPdfFromUrlencoded(@PathParam("kurs") String kurs, @PathParam("lang") String lang, @BeanParam KursParameterJson kpj) throws Exception {
+        System.out.println(kpj);
+
+        return renderPdf(kurs, lang, kpj);
     }
     
     public byte[] renderPdf(String kurs, String lang, KursParameterJson kpj) throws Exception{

--- a/src/main/java/ch/smartness/pbs/reporting/resources/KursRendererResource.java
+++ b/src/main/java/ch/smartness/pbs/reporting/resources/KursRendererResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
 import com.codahale.metrics.annotation.Timed;
@@ -20,6 +21,7 @@ import ch.smartness.pbs.reporting.uc.kursbestaetigung.KursParameter;
 import ch.smartness.pbs.reporting.uc.kursbestaetigung.xml.XMLAccessor;
 import ch.smartness.pbs.reporting.uc.kursbestaetigung.xml.XMLKursConfig;
 import ch.smartness.pbs.reporting.uc.kursbestaetigung.xml.XMLKursbeschreibung;
+import javax.ws.rs.core.Response;
 
 @Path("/kurs/renderer")
 @Produces(MediaType.APPLICATION_JSON)
@@ -58,11 +60,14 @@ public class KursRendererResource {
     @Path("/demo/pdf/{kurs}/{lang}")
     @Produces("application/pdf")
     @Timed
-    public byte[] getPdfDemo(@PathParam("kurs") String kurs, @PathParam("lang") String lang) throws Exception {
-        KursParameterJson parameter = createDemoParameter();
+    public Response getPdfDemo(@PathParam("kurs") String kurs, @PathParam("lang") String lang) throws Exception {
+    	KursParameterJson parameter = createDemoParameter();
+		
 
-
-        return renderPdf(kurs, lang, parameter);
+        return Response.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + kurs + ".pdf\"")
+                .entity(renderPdf(kurs, lang, parameter))
+                .build();
     }
 
     @POST
@@ -70,10 +75,13 @@ public class KursRendererResource {
     @Produces("application/pdf")
     @Consumes(MediaType.APPLICATION_JSON)
     @Timed
-    public byte[] getPdfFromJson(@PathParam("kurs") String kurs, @PathParam("lang") String lang, KursParameterJson kpj) throws Exception {
+    public Response getPdfFromJson(@PathParam("kurs") String kurs, @PathParam("lang") String lang, KursParameterJson kpj) throws Exception {
         System.out.println(kpj);
 
-        return renderPdf(kurs, lang, kpj);
+        return Response.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + kurs + ".pdf\"")
+                .entity(renderPdf(kurs, lang, kpj))
+                .build();
     }
 
     @POST
@@ -81,10 +89,13 @@ public class KursRendererResource {
     @Produces("application/pdf")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Timed
-    public byte[] getPdfFromUrlencoded(@PathParam("kurs") String kurs, @PathParam("lang") String lang, @BeanParam KursParameterJson kpj) throws Exception {
+    public Response getPdfFromUrlencoded(@PathParam("kurs") String kurs, @PathParam("lang") String lang, @BeanParam KursParameterJson kpj) throws Exception {
         System.out.println(kpj);
 
-        return renderPdf(kurs, lang, kpj);
+        return Response.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + kurs + ".pdf\"")
+                .entity(renderPdf(kurs, lang, kpj))
+                .build();
     }
     
     public byte[] renderPdf(String kurs, String lang, KursParameterJson kpj) throws Exception{

--- a/src/main/resources/assets/demo.html
+++ b/src/main/resources/assets/demo.html
@@ -19,7 +19,7 @@
   <li><a href="/kurs/renderer/demo/pdf/topkurs/de">Topkurs</a></li>
 </ul>
 
-<form id="form">
+<form action="/kurs/renderer/pdf/basiskurs/de" id="form" target="_blank" method="POST">
     <label for="name">Name</label><input type="text" id="name" name="name" value="Rengel">
     <label for="vorname">Vorname</label><input type="text" id="vorname" name="vorname" value="Heinrich">
     <label for="wohnort">Wohnort</label><input type="text" id="wohnort" name="wohnort" value="Oberdorf">
@@ -28,44 +28,8 @@
     <label for="organisator">Organisator</label><input type="text" id="organisator" name="organisator" value="Pfadibewegung Schweiz (PBS)">
     <label for="geburtstag">Geburtstag</label><input type="text" id="geburtstag" name="geburtstag" value="09.08.1977">
     <label for="anrede">Anrede</label><input type="text" id="anrede" name="anrede" value="Herr">
-    <div><button>Absenden</button></div>
+    <div><button type="submit">Absenden</button></div>
 </form>
-
-<script>
-    function submit() {
-        var formData = new FormData(document.querySelector('#form'));
-        var object = {};
-        formData.forEach(function (value, key) {
-            object[key] = value;
-        });
-        var json = JSON.stringify(object);
-        var xhr = new XMLHttpRequest();
-        xhr.open('POST', '/kurs/renderer/pdf/basiskurs/de', true);
-        xhr.setRequestHeader('Content-Type', 'application/json');
-        xhr.responseType = 'blob';
-        xhr.onload = function (event) {
-            var blob = xhr.response;
-            var contentDispo = xhr.getResponseHeader('Content-Disposition');
-            // https://stackoverflow.com/a/23054920/
-            var fileName = contentDispo.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/)[1];
-            saveBlob(blob, fileName);
-        };
-        xhr.send(json);
-    }
-
-    function saveBlob(blob, fileName) {
-        var a = document.createElement('a');
-        a.href = window.URL.createObjectURL(blob);
-        a.download = fileName;
-        a.dispatchEvent(new MouseEvent('click'));
-    }
-
-    var element = document.querySelector('#form');
-    element.addEventListener('submit', function (event) {
-        event.preventDefault();
-        submit();
-    });
-</script>
 
 </body>
 </html>

--- a/src/main/resources/assets/demo.html
+++ b/src/main/resources/assets/demo.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Kurs Renderer</title>
+<style>label { display: block; }</style>
 </head>
 <body>
 <h1>Kurs Renderer: Demo</h1>
@@ -17,6 +18,54 @@
   <li><a href="/kurs/renderer/demo/pdf/spektrumkurs/de">Spektrumkurs</a></li>
   <li><a href="/kurs/renderer/demo/pdf/topkurs/de">Topkurs</a></li>
 </ul>
+
+<form id="form">
+    <label for="name">Name</label><input type="text" id="name" name="name" value="Rengel">
+    <label for="vorname">Vorname</label><input type="text" id="vorname" name="vorname" value="Heinrich">
+    <label for="wohnort">Wohnort</label><input type="text" id="wohnort" name="wohnort" value="Oberdorf">
+    <label for="dauer">Kursdauer</label><input type="text" id="dauer" name="dauer" value="28.09.2017 - 29.09.2017">
+    <label for="kursOrt">Kursort</label><input type="text" id="kursOrt" name="kursOrt" value="Solothurn">
+    <label for="organisator">Organisator</label><input type="text" id="organisator" name="organisator" value="Pfadibewegung Schweiz (PBS)">
+    <label for="geburtstag">Geburtstag</label><input type="text" id="geburtstag" name="geburtstag" value="09.08.1977">
+    <label for="anrede">Anrede</label><input type="text" id="anrede" name="anrede" value="Herr">
+    <div><button>Absenden</button></div>
+</form>
+
+<script>
+    function submit() {
+        var formData = new FormData(document.querySelector('#form'));
+        var object = {};
+        formData.forEach(function (value, key) {
+            object[key] = value;
+        });
+        var json = JSON.stringify(object);
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', '/kurs/renderer/pdf/basiskurs/de', true);
+        xhr.setRequestHeader('Content-Type', 'application/json');
+        xhr.responseType = 'blob';
+        xhr.onload = function (event) {
+            var blob = xhr.response;
+            var contentDispo = xhr.getResponseHeader('Content-Disposition');
+            // https://stackoverflow.com/a/23054920/
+            var fileName = contentDispo.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/)[1];
+            saveBlob(blob, fileName);
+        };
+        xhr.send(json);
+    }
+
+    function saveBlob(blob, fileName) {
+        var a = document.createElement('a');
+        a.href = window.URL.createObjectURL(blob);
+        a.download = fileName;
+        a.dispatchEvent(new MouseEvent('click'));
+    }
+
+    var element = document.querySelector('#form');
+    element.addEventListener('submit', function (event) {
+        event.preventDefault();
+        submit();
+    });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Builds on #1. Add the content-disposition: attachment HTTP header to the PDF response, to make the browser download the PDF rather than display it. This enables smoother integration into external web applications that want to use the exporter.